### PR TITLE
fix: correct base URL in speech-to-text, text-to-speech, translate skills

### DIFF
--- a/speech-to-text/SKILL.md
+++ b/speech-to-text/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: sarvam-ai
-  version: "3.2"
+  version: "3.3"
 ---
 
 # Speech-to-Text — Saaras
@@ -16,7 +16,7 @@ metadata:
 > Live in-chat transcription → [sarvam-mcp](../sarvam-mcp) (`sarvam_tools_stt_*`). This skill = **SDK code**.
 
 > [!IMPORTANT]
-> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai/v1`
+> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai` (NOT `/v1` — that prefix is only for the OpenAI-compatible chat endpoint)
 
 ## Model
 

--- a/text-to-speech/SKILL.md
+++ b/text-to-speech/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: sarvam-ai
-  version: "3.2"
+  version: "3.3"
 ---
 
 # Text-to-Speech — Bulbul
@@ -16,7 +16,7 @@ metadata:
 > Live in-chat TTS → [sarvam-mcp](../sarvam-mcp) (`sarvam_tools_tts_*`). This skill = **SDK code**.
 
 > [!IMPORTANT]
-> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai/v1`
+> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai` (NOT `/v1` — that prefix is only for the OpenAI-compatible chat endpoint)
 
 ## Model
 

--- a/translate/SKILL.md
+++ b/translate/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: sarvam-ai
-  version: "3.2"
+  version: "3.3"
 ---
 
 # Translation — Sarvam AI
@@ -16,7 +16,7 @@ metadata:
 > Live in-chat translate/localize → [sarvam-mcp](../sarvam-mcp) (`sarvam_tools_translate` / `_localize`). This skill = **SDK code**.
 
 > [!IMPORTANT]
-> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai/v1`
+> Auth: `api-subscription-key` header — NOT `Authorization: Bearer`. Base URL: `https://api.sarvam.ai` (NOT `/v1` — that prefix is only for the OpenAI-compatible chat endpoint)
 
 ## Models
 


### PR DESCRIPTION
All three skills state \`Base URL: https://api.sarvam.ai/v1\` in their \`[!IMPORTANT]\` line, but that \`/v1\` prefix only exists for the OpenAI-compatible chat endpoint. The actual STT/TTS/translate REST endpoints live directly under \`https://api.sarvam.ai\` with no \`/v1\`.

Verified live, same key, same day:
- \`POST /v1/text-to-speech\` -> 404, \`POST /text-to-speech\` -> 200
- \`POST /v1/speech-to-text\` -> 404, \`POST /speech-to-text\` -> 400 (expected validation error — endpoint exists)
- \`POST /v1/translate\` -> 404, \`POST /translate\` -> 200

Anyone hand-rolling a request from these skills' stated base URL hits a 404 before ever reaching a real error. This doesn't affect the official SDK (it resolves the correct paths internally) — it only affects anyone reading the skill and constructing requests manually, which is exactly the audience the \`[!IMPORTANT]\` callout is for.

Bumped versions 3.2 -> 3.3 on all three files.