### PR TITLE
Enhanced the README with SDK usage and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,25 @@ npm install sarvamai    # JavaScript/TypeScript
 # uvx sarvam-mcp  — see sarvam-mcp/references/install.md for each client
 ```
 
-Works with **Cursor**, **Claude Code**, **Windsurf**, and any agent that supports the [Agent Skills specification](https://agentskills.io/specification). The MCP skill also covers Claude Desktop, Zed, Codex, Gemini CLI, VS Code, Cline, Continue, and LM Studio.
+## SDK usage & naming
+
+Quick mapping for the SDK examples used in this repo and how to authenticate.
+
+| Language | Client / constructor | Auth (preferred) | Notes / example |
+|----------|----------------------|------------------:|-----------------|
+| Python   | `from sarvamai import SarvamAI` → `client = SarvamAI()` | `SARVAM_API_KEY` env OR `~/.sarvam/credentials` (`api_key = sk_...`) | Examples in SKILL.md use the environment/credentials pattern; prefer env for CI. |
+| JavaScript / TypeScript | `import { SarvamAIClient } from "sarvamai";` → `const client = new SarvamAIClient({ apiSubscriptionKey: "sk_..." })` | Pass `apiSubscriptionKey` in constructor or set `SARVAM_API_KEY` env (client may read env) | The JS/TS constructor accepts `apiSubscriptionKey` in examples for clarity. |
+
+Working curl example (sets the required header directly):
+```bash
+curl -sS -X POST "https://api.sarvam.ai/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "api-subscription-key: sk_..." \
+  -d '{"model":"sarvam-30b","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+Note about OpenAI-compatible wrappers
+- The Sarvam HTTP API expects the `api-subscription-key` header (or credentials file / env). Some OpenAI client libraries automatically send `Authorization: Bearer <key>` and do not let you change header names. If you use an OpenAI-compatible client with `base_url="https://api.sarvam.ai/v1"`, verify that it sends the correct header; otherwise use a tiny proxy or a request middleware that injects `api-subscription-key` (or call the API with curl/fetch/axios where you control headers).
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ For **in-chat** Sarvam actions (translate this, speak that, dub audio) across Cu
 
 The [vibe-coding](./vibe-coding) skill is **stack- and vendor-agnostic**—it is for anyone building with an agent. [sarvam-mcp](./sarvam-mcp) teaches agents to drive the Sarvam MCP server in any harness. The other skills document **Sarvam** SDK APIs for writing code.
 
-| Skill | Description |
-|-------|-------------|
-| [sarvam-mcp](./sarvam-mcp) | **MCP (any harness)** — live `sarvam_tools_*` vs build-time `sarvam_code_*`, composites, auth, install. Use for in-chat Sarvam actions. |
-| [chat](./chat) | **SDK** — Sarvam-105B/30B completions, streaming, reasoning, `content=None` gotcha. |
-| [speech-to-text](./speech-to-text) | **SDK** — Saaras v3 REST, Batch + diarization, WebSocket streaming. |
-| [text-to-speech](./text-to-speech) | **SDK** — Bulbul v3 REST/stream/WebSocket, pronunciation dicts, v3 param traps. |
-| [translate](./translate) | **SDK** — Mayura / Sarvam-Translate signatures and silent failures. |
-| [voice-agents](./voice-agents) | **SDK** — LiveKit / Pipecat real-time voice agents. |
-| [vibe-coding](./vibe-coding) | **Vendor-neutral** agent habits (slice → verify → iterate). Pair with a domain skill for APIs. |
+| Skill                              | Description                                                                                                                             |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [sarvam-mcp](./sarvam-mcp)         | **MCP (any harness)** — live `sarvam_tools_*` vs build-time `sarvam_code_*`, composites, auth, install. Use for in-chat Sarvam actions. |
+| [chat](./chat)                     | **SDK** — Sarvam-105B/30B completions, streaming, reasoning, `content=None` gotcha.                                                     |
+| [speech-to-text](./speech-to-text) | **SDK** — Saaras v3 REST, Batch + diarization, WebSocket streaming.                                                                     |
+| [text-to-speech](./text-to-speech) | **SDK** — Bulbul v3 REST/stream/WebSocket, pronunciation dicts, v3 param traps.                                                         |
+| [translate](./translate)           | **SDK** — Mayura / Sarvam-Translate signatures and silent failures.                                                                     |
+| [voice-agents](./voice-agents)     | **SDK** — LiveKit / Pipecat real-time voice agents.                                                                                     |
+| [vibe-coding](./vibe-coding)       | **Vendor-neutral** agent habits (slice → verify → iterate). Pair with a domain skill for APIs.                                          |
 
 ## Installation
 
@@ -59,34 +59,41 @@ npm install sarvamai    # JavaScript/TypeScript
 # uvx sarvam-mcp  — see sarvam-mcp/references/install.md for each client
 ```
 
+Works with **Cursor**, **Claude Code**, **Windsurf**, and any agent that supports the [Agent Skills specification](https://agentskills.io/specification). The MCP skill also covers Claude Desktop, Zed, Codex, Gemini CLI, VS Code, Cline, Continue, and LM Studio.
+
 ## SDK usage & naming
 
-Quick mapping for the SDK examples used in this repo and how to authenticate.
+The examples in this repository use different SDK client names across Python and JavaScript/TypeScript. The table below shows the canonical constructors and recommended authentication methods.
 
-| Language | Client / constructor | Auth (preferred) | Notes / example |
-|----------|----------------------|------------------:|-----------------|
-| Python   | `from sarvamai import SarvamAI` → `client = SarvamAI()` | `SARVAM_API_KEY` env OR `~/.sarvam/credentials` (`api_key = sk_...`) | Examples in SKILL.md use the environment/credentials pattern; prefer env for CI. |
-| JavaScript / TypeScript | `import { SarvamAIClient } from "sarvamai";` → `const client = new SarvamAIClient({ apiSubscriptionKey: "sk_..." })` | Pass `apiSubscriptionKey` in constructor or set `SARVAM_API_KEY` env (client may read env) | The JS/TS constructor accepts `apiSubscriptionKey` in examples for clarity. |
+| Language                | SDK client                                             | Recommended authentication                                       |
+| ----------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| Python                  | `from sarvamai import SarvamAI`                        | `SARVAM_API_KEY` environment variable or `~/.sarvam/credentials` |
+| JavaScript / TypeScript | `new SarvamAIClient({ apiSubscriptionKey: "sk_..." })` | `apiSubscriptionKey` constructor option                          |
 
-Working curl example (sets the required header directly):
+You can verify that your API key works with a simple `curl` request:
+
 ```bash
 curl -sS -X POST "https://api.sarvam.ai/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "api-subscription-key: sk_..." \
-  -d '{"model":"sarvam-30b","messages":[{"role":"user","content":"Hello"}]}'
+  -d '{
+    "model": "sarvam-30b",
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
 ```
 
-Note about OpenAI-compatible wrappers
-- The Sarvam HTTP API expects the `api-subscription-key` header (or credentials file / env). Some OpenAI client libraries automatically send `Authorization: Bearer <key>` and do not let you change header names. If you use an OpenAI-compatible client with `base_url="https://api.sarvam.ai/v1"`, verify that it sends the correct header; otherwise use a tiny proxy or a request middleware that injects `api-subscription-key` (or call the API with curl/fetch/axios where you control headers).
+**Note:** Sarvam APIs use the `api-subscription-key` header. If you use an OpenAI-compatible client or wrapper with a custom `base_url`, make sure it sends `api-subscription-key` rather than `Authorization: Bearer`, or use a proxy/middleware that injects the required header.
 
 ## How It Works
 
 ```
 sarvam-mcp/SKILL.md     ← MCP routing (tools_* vs code_*) for any harness
-SDK skill/SKILL.md       ← SDK signatures + gotchas (what agents get wrong)
+SDK skill/SKILL.md      ← SDK signatures + gotchas (what agents get wrong)
     │
     ▼
-llms.txt / MCP code_*    ← Always-fresh docs index or live API reference tools
+llms.txt / MCP code_*   ← Always-fresh docs index or live API reference tools
     │
     ▼
 Full API docs, OpenAPI spec, cookbooks, voice catalog, streaming protocols...
@@ -94,21 +101,21 @@ Full API docs, OpenAPI spec, cookbooks, voice catalog, streaming protocols...
 
 **sarvam-mcp** teaches agents when to call live MCP tools vs build-time helpers, and how to install the server in each client. The other Sarvam skills are a lean **correction layer** with both **Python** and **JavaScript/TypeScript** SDK snippets — only what AI agents get wrong when generating Sarvam AI code:
 
-- **SDK call signatures** that differ from conventions (e.g., no `.create()` on chat)
-- **Parameters that silently fail** (e.g., `output_script` ignored on sarvam-translate)
-- **Parameters that error** (e.g., `pitch`/`loudness` returns 400 on Bulbul v3)
-- **Non-trivial SDK patterns** (e.g., Batch API job chain, WebSocket async connect)
+* **SDK call signatures** that differ from conventions (e.g., no `.create()` on chat)
+* **Parameters that silently fail** (e.g., `output_script` ignored on sarvam-translate)
+* **Parameters that error** (e.g., `pitch`/`loudness` returns 400 on Bulbul v3)
+* **Non-trivial SDK patterns** (e.g., Batch API job chain, WebSocket async connect)
 
 For everything else — full parameter tables, voice catalogs, language codes, rate limits, cookbook examples — the skill points to [llms.txt](https://docs.sarvam.ai/llms.txt), which is always up to date.
 
 ## Links
 
-- [API Documentation](https://docs.sarvam.ai)
-- [llms.txt](https://docs.sarvam.ai/llms.txt)
-- [Dashboard](https://dashboard.sarvam.ai)
-- [Cookbook](https://github.com/sarvamai/sarvam-ai-cookbook)
-- [Discord](https://discord.com/invite/5rAsykttcs)
-- [GitHub](https://github.com/sarvamai)
+* [API Documentation](https://docs.sarvam.ai)
+* [llms.txt](https://docs.sarvam.ai/llms.txt)
+* [Dashboard](https://dashboard.sarvam.ai)
+* [Cookbook](https://github.com/sarvamai/sarvam-ai-cookbook)
+* [Discord](https://discord.com/invite/5rAsykttcs)
+* [GitHub](https://github.com/sarvamai)
 
 ## License
 


### PR DESCRIPTION
## Summary

* Adds an **SDK usage & naming** section to `README.md` with a small mapping table for Python vs JavaScript/TypeScript clients, a working `curl` example that demonstrates the required `api-subscription-key` header, and a short note about OpenAI-compatible client header caveats.

## Problem

Existing documentation used mixed constructor names and authentication patterns across examples (for example, `SarvamAI()` in Python vs `SarvamAIClient({ apiSubscriptionKey: ... })` in JavaScript), and the OpenAI-compatible example could mislead users because Sarvam requires `api-subscription-key` while some OpenAI wrappers send `Authorization: Bearer`. This caused confusion and friction for new users trying the examples.

## What I changed

* Added a concise **SDK usage & naming** section to `README.md` that includes:

  * A table mapping the Python client and JavaScript/TypeScript client constructors and their recommended authentication methods.
  * A `curl` example showing the exact header name Sarvam expects (`api-subscription-key`).
  * A short note explaining the OpenAI-wrapper header caveat and recommending middleware/proxy or direct HTTP calls when necessary.

## Why this helps

* Makes examples consistent and reduces onboarding friction for new users.
* Gives a quick verification command (`curl`) so users can validate API keys immediately.
* Lowers support noise by preventing a common source of error (using the wrong authentication header).

## Files changed

* `README.md` (documentation only)